### PR TITLE
Optimize bitvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [workspace]
 members = [
     "wfc_core",

--- a/wfc_cli/src/text_io.rs
+++ b/wfc_cli/src/text_io.rs
@@ -301,7 +301,7 @@ pub fn import_world_state<R: io::BufRead>(
     Ok(())
 }
 
-// FIXME: Error handling for writing
+// TODO(yan): Error handling for writing
 pub fn export_world_state<W: io::Write>(
     w: &mut W,
     world: &World,
@@ -313,7 +313,7 @@ pub fn export_world_state<W: io::Write>(
     assert!(dims[1] > 0);
     assert!(dims[2] > 0);
 
-    // FIXME: Formatting for multichar names
+    // TODO(yan): Formatting for multichar names
     let largest_slot = {
         let mut largest = 0;
 

--- a/wfc_core/src/bitvec.rs
+++ b/wfc_core/src/bitvec.rs
@@ -8,8 +8,8 @@ pub struct BitVec {
     /// The data and length of the bit vector.
     ///
     /// The last eight bits represent the length and the first 248 bits contain
-    /// the data itself. While the length could be be computed every time with
-    /// [`u64::count_ones`], the intrinsic showed up on in profiling quite a lot
+    /// the data itself. While the length could be computed every time with
+    /// [`u64::count_ones`], the intrinsic showed up in profiling quite a lot
     /// and it is just faster to use the cached value.
     data: [u64; 4],
 }

--- a/wfc_core/src/bitvec.rs
+++ b/wfc_core/src/bitvec.rs
@@ -1,27 +1,29 @@
-use std::mem;
+pub const MAX_LEN: u8 = u8::MAX - 8;
+pub const MAX_LEN_U64: u64 = MAX_LEN as u64;
+
+const DATA_MASK: u64 = u64::MAX >> 8;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BitVec {
+    /// The data and length of the bit vector.
+    ///
+    /// The last eight bits represent the length and the first 248 bits contain
+    /// the data itself. While the length could be be computed every time with
+    /// [`u64::count_ones`], the intrinsic showed up on in profiling quite a lot
+    /// and it is just faster to use the cached value.
     data: [u64; 4],
 }
 
 impl BitVec {
     /// Creates a new bit vector with all bits set to zero.
-    pub fn zeros() -> Self {
+    pub const fn zeros() -> Self {
         Self { data: [0; 4] }
-    }
-
-    /// Creates a new bit vector with all bits set to one.
-    pub fn ones() -> Self {
-        Self {
-            data: [u64::MAX; 4],
-        }
     }
 
     /// Returns whether the bit vector has a bit set.
     pub fn contains(&self, index: u8) -> bool {
+        assert!(index < MAX_LEN);
         let index = usize::from(index);
-        debug_assert!(index < mem::size_of::<[u64; 4]>() * 8);
 
         let blk_index = index / 64;
         let bit_index = index % 64;
@@ -33,8 +35,8 @@ impl BitVec {
     /// Sets a bit in the vector to one. Returns `true` if the bit was not
     /// previously set.
     pub fn add(&mut self, index: u8) -> bool {
+        assert!(index < MAX_LEN);
         let index = usize::from(index);
-        debug_assert!(index < mem::size_of::<[u64; 4]>() * 8);
 
         let blk_index = index / 64;
         let bit_index = index % 64;
@@ -42,14 +44,19 @@ impl BitVec {
 
         self.data[blk_index] |= 1 << bit_index;
 
-        value == 0
+        if value == 0 {
+            self.inc_len();
+            true
+        } else {
+            false
+        }
     }
 
     /// Sets a bit in the vector to zero. Returns `true` if the bit was
     /// previously set.
     pub fn remove(&mut self, index: u8) -> bool {
+        assert!(index < MAX_LEN);
         let index = usize::from(index);
-        debug_assert!(index < mem::size_of::<[u64; 4]>() * 8);
 
         let blk_index = index / 64;
         let bit_index = index % 64;
@@ -57,20 +64,18 @@ impl BitVec {
 
         self.data[blk_index] &= !(1 << bit_index);
 
-        value != 0
+        if value != 0 {
+            self.dec_len();
+            true
+        } else {
+            false
+        }
     }
 
     /// Returns the number of ones in the binary representation of the bit
     /// vector.
     pub fn len(&self) -> usize {
-        // usize is defined to be at least 16 bits wide, the following `as`
-        // casts should be ok for up to 2^16 ones in the whole array.
-        let c0 = self.data[0].count_ones() as usize;
-        let c1 = self.data[1].count_ones() as usize;
-        let c2 = self.data[2].count_ones() as usize;
-        let c3 = self.data[3].count_ones() as usize;
-
-        c0 + c1 + c2 + c3
+        (self.data[3] >> 56) as usize
     }
 
     /// Sets all bits in the bit vector to zero.
@@ -86,50 +91,36 @@ impl BitVec {
         }
     }
 
-    /// Performs a bitwise AND operation between this bit vector and other.
-    pub fn and(&mut self, other: &BitVec) {
-        self.data[0] &= other.data[0];
-        self.data[1] &= other.data[1];
-        self.data[2] &= other.data[2];
-        self.data[3] &= other.data[3];
+    fn inc_len(&mut self) {
+        let mut len = self.data[3] >> 56;
+        assert!(len < MAX_LEN_U64);
+
+        len += 1;
+
+        self.data[3] = (self.data[3] & DATA_MASK) | (len << 56);
     }
 
-    /// Performs a bitwise OR operation between this bit vector and other.
-    pub fn or(&mut self, other: &BitVec) {
-        self.data[0] |= other.data[0];
-        self.data[1] |= other.data[1];
-        self.data[2] |= other.data[2];
-        self.data[3] |= other.data[3];
-    }
+    fn dec_len(&mut self) {
+        let mut len = self.data[3] >> 56;
+        assert!(len > 0);
 
-    /// Performs a bitwise XOR operation between this bit vector and other.
-    pub fn xor(&mut self, other: &BitVec) {
-        self.data[0] ^= other.data[0];
-        self.data[1] ^= other.data[1];
-        self.data[2] ^= other.data[2];
-        self.data[3] ^= other.data[3];
-    }
+        len -= 1;
 
-    /// Performs a bitwise negation on this bit vector.
-    pub fn not(&mut self) {
-        self.data[0] &= !self.data[0];
-        self.data[1] &= !self.data[1];
-        self.data[2] &= !self.data[2];
-        self.data[3] &= !self.data[3];
+        self.data[3] = (self.data[3] & DATA_MASK) | (len << 56)
     }
 }
 
 pub struct BitVecIterator<'a> {
     bitvec: &'a BitVec,
-    next: u16,
+    next: u8,
 }
 
 impl<'a> Iterator for BitVecIterator<'a> {
     type Item = u8;
 
     fn next(&mut self) -> Option<u8> {
-        while self.next <= u16::from(u8::MAX) {
-            let index = self.next as u8;
+        while self.next < MAX_LEN {
+            let index = self.next;
 
             let contains = self.bitvec.contains(index);
             self.next += 1;
@@ -150,10 +141,15 @@ impl<'a> Iterator for BitVecIterator<'a> {
 
         let n = u32::from(self.next);
 
-        let m0 = u64::MAX.checked_shl(n).unwrap_or(0);
-        let m1 = u64::MAX.checked_shl(n.saturating_sub(64)).unwrap_or(0);
-        let m2 = u64::MAX.checked_shl(n.saturating_sub(64 * 2)).unwrap_or(0);
-        let m3 = u64::MAX.checked_shl(n.saturating_sub(64 * 3)).unwrap_or(0);
+        let shl0 = n;
+        let shl1 = n.saturating_sub(64);
+        let shl2 = n.saturating_sub(64 * 2);
+        let shl3 = n.saturating_sub(64 * 3);
+
+        let m0 = u64::MAX.checked_shl(shl0).unwrap_or(0);
+        let m1 = u64::MAX.checked_shl(shl1).unwrap_or(0);
+        let m2 = u64::MAX.checked_shl(shl2).unwrap_or(0);
+        let m3 = u64::MAX.checked_shl(shl3).unwrap_or(0) & DATA_MASK;
 
         // Mask out spent bits and count how many set bits remain.
 

--- a/wfc_core/src/lib.rs
+++ b/wfc_core/src/lib.rs
@@ -111,6 +111,7 @@ pub struct World {
 
 impl World {
     pub fn new(dims: [u16; 3], adjacencies: Vec<Adjacency>) -> Self {
+        // TODO(yan): Error handling. Do not unwind across FFI.
         assert!(dims[0] > 0);
         assert!(dims[1] > 0);
         assert!(dims[2] > 0);
@@ -122,6 +123,9 @@ impl World {
         let mut module_max = 0;
 
         for adjacency in &adjacencies {
+            assert!(adjacency.module_low < bitvec::MAX_LEN);
+            assert!(adjacency.module_high < bitvec::MAX_LEN);
+
             if modules.add(adjacency.module_low) {
                 module_count += 1;
             }
@@ -553,7 +557,7 @@ where
     // non-64bit platforms.
     let rand_num = rng.next_u64() as usize;
 
-    // FIXME: @Correctness How should we correctly create the index from the
+    // TODO(yan): @Correctness How should we correctly create the index from the
     // random number to preserve the uniformity of the sampled distribution?
     let index = rand_num % size_hint_low;
     iter.nth(index).unwrap()

--- a/wfc_dylib/ffi/wfc.h
+++ b/wfc_dylib/ffi/wfc.h
@@ -49,6 +49,13 @@ typedef struct AdjacencyRule {
 typedef Pcg32 *WfcRngStateHandle;
 
 /**
+ * Returns the maximum module count supported to be sent with
+ * [`wfc_world_state_slots_get`] and [`wfc_world_state_slots_set`] by the
+ * implementation.
+ */
+uint32_t wfc_max_module_count_get(void);
+
+/**
  * Creates an instance of Wave Function Collapse world state and initializes it
  * with adjacency rules. The world gets initialized with every module possible
  * in every slot.

--- a/wfc_dylib/ffi/wfc.hpp
+++ b/wfc_dylib/ffi/wfc.hpp
@@ -43,6 +43,11 @@ using WfcRngStateHandle = Pcg32*;
 
 extern "C" {
 
+/// Returns the maximum module count supported to be sent with
+/// [`wfc_world_state_slots_get`] and [`wfc_world_state_slots_set`] by the
+/// implementation.
+uint32_t wfc_max_module_count_get();
+
 /// Creates an instance of Wave Function Collapse world state and initializes it
 /// with adjacency rules. The world gets initialized with every module possible
 /// in every slot.

--- a/wfc_gh/Info.cs
+++ b/wfc_gh/Info.cs
@@ -18,7 +18,7 @@ namespace wfc_gh
 
         public override Guid Id => new Guid("1277e762-d959-464b-a68c-b4881d99b969");
         public override string Name => "WFC Solver";
-        // FIXME: Use another icon here?
+        // TODO(yan): Use another icon here?
         public override System.Drawing.Bitmap Icon => componentIcon;
         public override string Description => "Wave Function Collapse solver(s)";
         public override string AuthorName => "Subdigital";

--- a/wfc_gh/WaveFunctionCollapse.cs
+++ b/wfc_gh/WaveFunctionCollapse.cs
@@ -130,9 +130,10 @@ namespace wfc_gh
                 return;
             }
 
-            // We need to check ahead of time, if there are at most 256 modules
-            // altogether in the input, otherwise the `nextModule` variable will
-            // overflow and cause a dictionary error.
+            // We need to check ahead of time, if there are at most
+            // maxModuleCount modules altogether in the input, otherwise
+            // nextModule will overflow and cause a dictionary error.
+            uint maxModuleCount = Native.wfc_max_module_count_get();
             {
                 HashSet<string> allModules = new HashSet<string>();
 
@@ -142,10 +143,10 @@ namespace wfc_gh
                     allModules.Add(adjacencyRulesModuleHigh[i]);
                 }
 
-                if (allModules.Count > 256)
+                if (allModules.Count > maxModuleCount)
                 {
                     AddRuntimeMessage(GH_RuntimeMessageLevel.Error,
-                                      "Too many modules. Maximum allowed is 256");
+                                      "Too many modules. Maximum allowed is " + maxModuleCount);
                     return;
                 }
             }
@@ -255,8 +256,10 @@ namespace wfc_gh
             // -- World slot positions and modules --
             //
 
-            // This array is re-used for both input and output (if input world state was provided).
-            // This is ok, because wfc_world_state_get does clear it to zero before writing to it.
+            // This array is re-used for both input and output (if input world
+            // state was provided). This is ok, because
+            // wfc_world_state_slots_get does clear it to zero before writing to
+            // it.
             var slots = new SlotState[worldDimensions];
 
             // ... WE do need to clear it to zero, however. C# does not initialize slot_state for us!
@@ -337,9 +340,10 @@ namespace wfc_gh
             //
             // -- Random seed --
             //
-            // wfc_init needs 128 bits worth of random seed, but that is tricky to provide from GH.
-            // We let GH provide an int, use it to seed a C# Random, get 16 bytes of data from that
-            // and copy those into two u64's.
+            // wfc_rng_state_init needs 128 bits worth of random seed, but that
+            // is tricky to provide from GH.  We let GH provide an int, use it
+            // to seed a C# Random, get 16 bytes of data from that and copy
+            // those into two u64's.
 
             int randomSeed = 0;
             DA.GetData(IN_PARAM_RANDOM_SEED, ref randomSeed);
@@ -617,6 +621,9 @@ namespace wfc_gh
 
     internal class Native
     {
+        [DllImport("wfc", CallingConvention = CallingConvention.StdCall)]
+        internal static extern uint wfc_max_module_count_get();
+
         [DllImport("wfc", CallingConvention = CallingConvention.StdCall)]
         internal static unsafe extern WfcWorldStateInitResult wfc_world_state_init(IntPtr* wfc_world_state_handle_ptr,
                                                                                    AdjacencyRule* adjacency_rules_ptr,

--- a/wfc_gh/wfc_gh.csproj
+++ b/wfc_gh/wfc_gh.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- FIXME: We would like to target netstandard2.1, but GH uses
+    <!-- TODO(yan): We would like to target netstandard2.1, but GH uses
     System.Drawing from .NET Framework, so we have to use netXY -->
     <!--<TargetFramework>netstandard2.1</TargetFramework>-->
     <TargetFramework>net48</TargetFramework>


### PR DESCRIPTION
This speeds up the solver by 28% (measured in macro-benchmarks with `time cargo run --release ./samples/sample3.csv -x 100 -y 100 -z 100`. The optimization was guided by profiling.

`BitVec::len` is called very often by the solver, and internally it was calling `u64::count_ones` intrinsics which showed up significantly on the flamegraph. The patch changes `BitVec::len` to instead return a cached length of the bit vector. The length is stored in the last eight bits of data, so our module count decreased from 256 to 248.

A couple of unused methods were removed from `BitVec` so that they didn't have to be adapted to the new data layout.



~The PR is still draft, because I didn't test it integrated with GH just yet (I was on linux, because it getting a profiler to work under windows is trying). I'll test in GH soon and then undraft the PR, but it can be reviewed meanwhile.~

**UPDATE:** Tested with grasshopper integration.