### PR TITLE
Use bump allocators for more stable memory use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +64,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+
+[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +80,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -152,6 +175,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+ "bumpalo",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +255,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -238,6 +282,12 @@ checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "oorandom"
@@ -442,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "wfc_cli"
 version = "0.1.0"
 dependencies = [
@@ -460,7 +516,9 @@ name = "wfc_core"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "bumpalo",
  "fxhash",
+ "hashbrown",
  "oorandom",
 ]
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.53.0"
+channel = "nightly-2021-12-06"
 components = ["rustfmt", "clippy"]

--- a/wfc_cli/src/main.rs
+++ b/wfc_cli/src/main.rs
@@ -151,7 +151,7 @@ fn main() {
 
             match status {
                 WorldStatus::Nondeterministic => {
-                    if observations % 100 == 0 {
+                    if observations % 1000 == 0 {
                         eprintln!(
                             "attempt: {:>4}, observation: {:>4}, {} (In progress)",
                             attempts, observations, status,

--- a/wfc_core/Cargo.toml
+++ b/wfc_core/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2018"
 
 [dependencies]
 arrayvec = "0.7.1"
+bumpalo = { version = "3.8.0", features = ["allocator_api"] }
 fxhash = "0.2.1"
+hashbrown = { version = "0.11.2", features = ["bumpalo"] }
 oorandom = "11.1.3"

--- a/wfc_core/src/lib.rs
+++ b/wfc_core/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(allocator_api)]
+
 mod bitvec;
 mod convert;
 mod world;


### PR DESCRIPTION
This converts a few places using the global allocator for temporary memory to use a bump allocator instead. In practice, no wall time benefits show up on macro benchmarks, but we do see improved memory use (which is likely just a side effect of the OS committing less memory than we request)